### PR TITLE
feat: parse numbers

### DIFF
--- a/social/farcaster/lambda-farcaster-action/index.cts
+++ b/social/farcaster/lambda-farcaster-action/index.cts
@@ -13,7 +13,9 @@ const handler: Handler = async (event, context) => {
 
   const cast = await publishCast(
     wallet,
-    `Whale Alert: ${eventBody.value} of USDC moved from ${eventBody.from} to ${eventBody.to}`
+    `Whale Alert: ${new Intl.NumberFormat("en-US").format(
+      eventBody.value
+    )} of USDC moved from ${eventBody.from} to ${eventBody.to}`
   );
 
   console.log("Cast published: " + cast.hash);


### PR DESCRIPTION
We are parsing numbers using `Intl.NumberFormat` so they are more readable when sharing new whale alerts.